### PR TITLE
Replace erroneous reference to Chef::Application

### DIFF
--- a/recipes/_find_master.rb
+++ b/recipes/_find_master.rb
@@ -24,7 +24,7 @@ include_recipe 'redis-multi::_base'
 if Chef::Config[:solo]
   errmsg = 'This recipe uses search if master attribute is not set. \
    Chef Solo does not support search.'
-  Chef::Application.warn(errmsg)
+  Chef::Log.warn(errmsg)
 elsif node.deep_fetch('redis-multi', 'redis_master').nil?
   master = search('node', 'tags:redis_master'\
                   " AND chef_environment:#{node.chef_environment}")

--- a/recipes/find_all.rb
+++ b/recipes/find_all.rb
@@ -13,7 +13,7 @@ include_recipe 'redis-multi::_base'
 if Chef::Config[:solo]
   errmsg = 'This recipe uses search if all attribute is not set. \
     Chef Solo does not support search.'
-  Chef::Application.warn(errmsg)
+  Chef::Log.warn(errmsg)
 else # don't reuse old attribute 'all', freshen it
   all_ips = []
   found_nodes = search('node', 'tags:redis'\
@@ -26,7 +26,7 @@ else # don't reuse old attribute 'all', freshen it
     node.set['redis-multi']['all'] = all_ips
   else
     errmsg = 'Did not find Redis nodes to use, but none were set'
-    Chef::Application.warn(errmsg)
+    Chef::Log.warn(errmsg)
     # don't fail hard
   end
 end


### PR DESCRIPTION
The warning method doesn't exist on Chef::Application, should be
Chef::Log.warn()
